### PR TITLE
Add viewport meta to html files

### DIFF
--- a/resume-source-code/index.html
+++ b/resume-source-code/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>GDI Mpls - Building with Bootstrap</title>
 
   <link rel="stylesheet" href="css/bootstrap.min.css">
@@ -12,7 +13,7 @@
   <header>
     <nav class="navbar navbar-default navbar-fixed-top text-center">
       <div class="container-fluid">
-        
+
         <!-- mobile menu button -->
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
           <span class="sr-only">Toggle navigation</span>
@@ -20,7 +21,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        
+
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="navbar">
           <ul class="nav navbar-nav">

--- a/resume/index.html
+++ b/resume/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Resume Site - Building with Bootstrap - GDI Minneapolis</title>
 </head>
 <body>
-	
+
 </body>
 </html>

--- a/slide-demo/container-fluid.html
+++ b/slide-demo/container-fluid.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Container Fluid - Building with Bootstrap - GDI Minneapolis</title>
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
   <style>

--- a/slide-demo/container.html
+++ b/slide-demo/container.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Container - Building with Bootstrap - GDI Minneapolis</title>
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
   <style>

--- a/slide-demo/demo.html
+++ b/slide-demo/demo.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Building with Bootstrap Demo - GDI Minneapolis</title>
 </head>
 <body>


### PR DESCRIPTION
- maybe this should be part of the instruction instead?

Most responsive designs require the viewport meta to work well on phones and tablets, which may need to resize things because of a smaller viewport. It should be part of the standard web page boilerplate.

